### PR TITLE
Fix traffic flush interval dependency reference

### DIFF
--- a/luci-app-bandix/htdocs/luci-static/resources/view/bandix/settings.js
+++ b/luci-app-bandix/htdocs/luci-static/resources/view/bandix/settings.js
@@ -687,7 +687,7 @@ return view.extend({
 		o.value('86400', _('24 hours'));
 		o.default = '600';
 		o.rmempty = false;
-		o.depends('traffic_persist_history', '1');
+		o.depends('traffic_enable_storage', '1');
 
 		// 添加历史流量周期（秒）
 		o = s.option(form.ListValue, 'traffic_realtime_window', _('Realtime Traffic Period'),


### PR DESCRIPTION
Update depends clause to use new config option name traffic_enable_storage instead of old traffic_persist_history.